### PR TITLE
feat: display prev soorah and next soorah links

### DIFF
--- a/src/app/[soorah]/[ayah]/page.tsx
+++ b/src/app/[soorah]/[ayah]/page.tsx
@@ -59,6 +59,9 @@ const AyahPage = async ({
 
   const { content, arabic, transliteration, prev, next } = out
 
+  const prevSoorah = !prev && soorah > 1 ? soorahList.find((soorahItem) => soorahItem.id === Number(soorah - 1))?.fullTitle : undefined
+  const nextSoorah = !next && soorah < 114 ? soorahList.find((soorahItem) => soorahItem.id === Number(soorah + 1))?.fullTitle : undefined
+
   return (
     <>
       <Bismillah />
@@ -74,7 +77,7 @@ const AyahPage = async ({
         {arabic}
       </li>
       <li>
-        <PaginateAyah {...{ soorah, ayah, prev, next, translator }} />
+        <PaginateAyah {...{ soorah, ayah, prev, prevSoorah, next, nextSoorah, translator }} />
       </li>
     </>
   )

--- a/src/components/PaginateAyah/PaginateAyah.test.tsx
+++ b/src/components/PaginateAyah/PaginateAyah.test.tsx
@@ -51,16 +51,32 @@ describe('PaginateAyah', () => {
     expect(nextLink).toBeInTheDocument()
   })
 
-  test('renders the last ayah when next is null', () => {
-    render(<PaginateAyah {...mockProps} next={null} />)
+  test('renders the first ayah when prevSoorah is available', () => {
+    render(<PaginateAyah {...mockProps} next={null} prevSoorah="əl-Fatihə surəsi" />)
 
     const ayahText = screen.getByText('5')
     const prevLink = screen.queryByText('4')
-    const nextLink = screen.queryByText('6')
+    const prevSoorahLink = screen.getByText('1. əl-Fatihə surəsi ←')
 
     expect(ayahText).toBeInTheDocument()
     expect(prevLink).toBeInTheDocument()
-    expect(nextLink).not.toBeInTheDocument()
+    expect(prevSoorahLink).toBeInTheDocument()
+
+    expect(prevLink).toBeInTheDocument()
+  })
+
+  test('renders the last ayah when nextSoorah is available', () => {
+    render(<PaginateAyah {...mockProps} next={null} nextSoorah="Ali İmran surəsi" />)
+
+    const ayahText = screen.getByText('5')
+    const prevLink = screen.queryByText('4')
+    const nextSoorahLink = screen.getByText('3. Ali İmran surəsi →')
+
+    expect(ayahText).toBeInTheDocument()
+    expect(prevLink).toBeInTheDocument()
+    expect(nextSoorahLink).toBeInTheDocument()
+
+    expect(prevLink).toBeInTheDocument()
   })
 
 })

--- a/src/components/PaginateAyah/PaginateAyah.tsx
+++ b/src/components/PaginateAyah/PaginateAyah.tsx
@@ -5,6 +5,8 @@ export type PaginateAyahProps = {
   ayah: number
   prev?: number | null
   next?: number | null
+  prevSoorah?: string | null
+  nextSoorah?: string | null
   translator?: number
 }
 
@@ -12,10 +14,22 @@ export const PaginateAyah = ({
   soorah,
   ayah,
   prev,
+  prevSoorah,
   next,
+  nextSoorah,
   translator,
 }: PaginateAyahProps): JSX.Element => (
   <div className="pagination">
+    {prevSoorah ? (
+      <Link
+        href={`/${soorah - 1}?t=${translator}`}
+        className="pagination-item"
+        prefetch={false}
+      >
+        {`${soorah - 1}. ${prevSoorah}`} &larr;
+      </Link>
+    ) : null}
+
     {prev ? (
       <Link
         href={`/${soorah}/${prev}?t=${translator}`}
@@ -35,6 +49,17 @@ export const PaginateAyah = ({
         prefetch={false}
       >
         {next}
+      </Link>
+    ) : null
+    }
+
+    {nextSoorah ? (
+      <Link
+        href={`/${soorah + 1}?t=${translator}`}
+        className="pagination-item"
+        prefetch={false}
+      >
+        {`${soorah + 1}. ${nextSoorah}`} &rarr;
       </Link>
     ) : null}
   </div>


### PR DESCRIPTION
## Description
In the beginning of the Ayah page we do not have prev link
In the end of the Ayah page we do not have next link

## What I have done
I have added prevSoorah and nextSoorah links, to navigate to the next or previous soorah

## How to verify
 - Quran.az -> /40/1 -> you should see the link to the prev soorah
 - Quran.az -> /1/7 -> you should see the link to the next soorah

## Checklist

- [x] All new and existing unit tests pass.
- [x] No new dependencies were installed.
- [x] No changes to the core functionality were made.
- [x] Removed any debugging or unnecessary code.